### PR TITLE
Allow trailing whitespace in jade files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.jade]
+trim_trailing_whitespace = false

--- a/source/index.jade
+++ b/source/index.jade
@@ -5,8 +5,8 @@ date: 2014-07-08 10:17:28
 section#conference.container
   h2.section-title Developer Conference
   p
-    strong Thunder Plains
-    | is a web and mobile developer conference organized by the
+    strong Thunder Plains 
+    | is a web and mobile developer conference organized by the 
     a(href="http://okcjs.com") Oklahoma City Javascript User Group
     | . The conference
     | focuses on JavaScript and related technologies in a wide variety of different use cases and
@@ -37,11 +37,11 @@ section#coc
   .container
     h2.section-title Code of Conduct
     p
-      | Before attending the conference,
+      | Before attending the conference, 
       a(href="https://github.com/techlahoma/CodeofConduct/wiki/Techlahoma-Code-of-Conduct") please review the Thunder Plains Code of Conduct
       | . The CoC applies to all attendees, speakers, volunteers, and vendors
       | at official and unofficial events by Thunder Plains and any location
-      | where attendees may be congregating.
+      | where attendees may be congregating. 
       a(href="mailto:info@thunderplainsconf.com") Contact us
       |  if you have questions about the COC.
     br
@@ -54,10 +54,9 @@ section#location
   .container
     h2.section-title Where it&#8217;s at
     p
-      | Located at the
+      | Located at the 
       a(href="http://www.coxconventioncenter.com/") Cox Convention Center
       |  in downtown Oklahoma City
       br
       | within walking distance of great hotels and restaurants.
   #map
-


### PR DESCRIPTION
This fixes issues where links would not have a space after.

Is everyone cool with .editorconfig? We can use whatever.
